### PR TITLE
rm unused links & meta from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,15 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rick and Morty characters</title>
     <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="shortcut icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <meta name="apple-mobile-web-app-title" content="MyWebSite" />
-    <link rel="manifest" href="/site.webmanifest" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
This pull request includes a few changes to the `index.html` file, mainly related to the favicon and meta tags.

Changes to favicon and meta tags:

* Removed the link to the `vite.svg` icon and replaced it with a link to a `favicon-96x96.png` icon.
* Removed the `apple-mobile-web-app-title` meta tag.
* Removed the link to the `site.webmanifest` file.